### PR TITLE
Fix event startDate handling in notification scheduling

### DIFF
--- a/src/services/notificationsService.ts
+++ b/src/services/notificationsService.ts
@@ -39,8 +39,22 @@ export const notificationsService = {
 
   async scheduleLocalEvent(event: CalendarEventLike) {
     if (!event.reminders || !event.assignees) return;
-    
-    const start = new Date(event.startDate);
+
+    let start: Date;
+    if (
+      event.startDate &&
+      typeof (event.startDate as any).toDate === 'function'
+    ) {
+      start = (event.startDate as any).toDate();
+    } else {
+      start = new Date(event.startDate as any);
+    }
+
+    if (isNaN(start.getTime())) {
+      console.warn('Invalid start date for event', event);
+      return;
+    }
+
     const now = Date.now();
     
     console.log('🔔 [scheduleLocalEvent] Event:', event.title);


### PR DESCRIPTION
## Summary
- support Timestamp-like objects in notification scheduling
- warn and skip invalid start dates

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848310cccc88327ab26fbc4c81867d5