### PR TITLE
Fix reminders type

### DIFF
--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -29,7 +29,7 @@ export interface CalendarEvent {
   color?: string;         // Couleur de l'événement
   recurrence?: EventRecurrence;
   recurrenceEndDate?: Date | Timestamp;
-  reminder?: number;      // Minutes avant l'événement pour le rappel
+  reminders?: number[] | null; // Minutes avant l'événement pour les rappels
   completed?: boolean;    // Pour les événements de type 'task' ou 'reminder'
   completedBy?: string;   // ID du membre qui a complété l'événement
   completedAt?: Date | Timestamp;


### PR DESCRIPTION
## Summary
- update `CalendarEvent` to use `reminders?: number[] | null`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483114b38883279de771a03d7175a3