### PR TITLE
Update weekly agenda layout

### DIFF
--- a/src/components/calendar/CalendarHeader.tsx
+++ b/src/components/calendar/CalendarHeader.tsx
@@ -112,7 +112,7 @@ const CalendarHeader: React.FC<CalendarHeaderProps> = ({
     navButton: {
       padding: 8,
       borderRadius: 8,
-      backgroundColor: theme.colors.primary,
+      backgroundColor: theme.colors.calendarNavBackground,
       minWidth: 40,
       minHeight: 40,
       alignItems: 'center',
@@ -121,7 +121,7 @@ const CalendarHeader: React.FC<CalendarHeaderProps> = ({
     navButtonText: {
       fontSize: 18,
       fontWeight: '600',
-      color: 'white',
+      color: theme.colors.calendarNavIcon,
     },
     currentDateText: {
       fontSize: 16,
@@ -131,8 +131,13 @@ const CalendarHeader: React.FC<CalendarHeaderProps> = ({
     todayButton: {
       paddingHorizontal: 12,
       paddingVertical: 6,
-      borderRadius: 6,
-      backgroundColor: theme.colors.primary,
+      borderRadius: 20,
+      backgroundColor: theme.colors.calendarTodayBackground,
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: 4,
+      elevation: 3,
     },
     todayButtonText: {
       fontSize: 14,

--- a/src/components/calendar/CalendarScreen.tsx
+++ b/src/components/calendar/CalendarScreen.tsx
@@ -161,6 +161,7 @@ const CalendarScreen: React.FC<CalendarScreenProps> = ({
             onDateSelect={selectDate}
             onEventCreate={handleEventCreate}
             familyMembers={familyMembers}
+            selectedDate={selectedDate}
           />
         );
       case 'day':

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -13,6 +13,7 @@ type WeekViewProps = {
   onDateSelect: (date: Date) => void;
   onEventCreate: (dateWithTime?: Date) => void;
   familyMembers: FamilyMember[];
+  selectedDate?: Date | null;
 };
 
 const WeekView: React.FC<WeekViewProps> = ({
@@ -21,7 +22,8 @@ const WeekView: React.FC<WeekViewProps> = ({
   onEventSelect,
   onDateSelect,
   onEventCreate,
-  familyMembers
+  familyMembers,
+  selectedDate
 }) => {
   const theme = useTheme();
   const { navigateToNextWeek, navigateToPreviousWeek } = useCalendar();
@@ -50,7 +52,7 @@ const WeekView: React.FC<WeekViewProps> = ({
   const getWeekDays = (date: Date) => {
     const startOfWeek = new Date(date);
     const day = startOfWeek.getDay();
-    const diff = startOfWeek.getDate() - day; // Dimanche = 0
+    const diff = startOfWeek.getDate() - ((day + 6) % 7); // Commencer la semaine le lundi
     startOfWeek.setDate(diff);
 
     const weekDays = [];
@@ -255,9 +257,10 @@ const WeekView: React.FC<WeekViewProps> = ({
   };
 
   const formatDayHeader = (date: Date) => {
-    const dayNames = ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam'];
+    const dayNames = ['LUN', 'MAR', 'MER', 'JEU', 'VEN', 'SAM', 'DIM'];
+    const index = (date.getDay() + 6) % 7;
     return {
-      dayName: dayNames[date.getDay()],
+      dayName: dayNames[index],
       dayNumber: date.getDate()
     };
   };
@@ -294,14 +297,40 @@ const WeekView: React.FC<WeekViewProps> = ({
       fontWeight: '500',
     },
     dayNumber: {
-      fontSize: 18,
+      fontSize: 16,
+      fontWeight: '600',
+    },
+    dayNumberWrapper: {
+      marginTop: 2,
+      paddingHorizontal: 6,
+      paddingVertical: 2,
+      borderRadius: 12,
+    },
+    dayNumberWrapperUnselected: {
+      backgroundColor: '#F5F5F5',
+    },
+    dayNumberWrapperSelected: {
+      backgroundColor: 'transparent',
+    },
+    dayNumberUnselected: {
       color: theme.colors.text,
       fontWeight: '600',
-      marginTop: 2,
     },
-    dayNumberToday: {
-      color: theme.colors.primary,
+    dayNumberSelected: {
+      color: theme.colors.calendarNavIcon,
       fontWeight: '700',
+    },
+    agendaContainer: {
+      flex: 1,
+      marginHorizontal: 16,
+      backgroundColor: theme.colors.card,
+      borderRadius: 12,
+      overflow: 'hidden',
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.05,
+      shadowRadius: 6,
+      elevation: 2,
     },
     scrollContainer: {
       flex: 1,
@@ -408,7 +437,9 @@ const WeekView: React.FC<WeekViewProps> = ({
             {weekDays.map((day, index) => {
               const { dayName, dayNumber } = formatDayHeader(day);
               const isTodayDate = isToday(day);
-              
+              const isSelectedDate =
+                selectedDate && day.toDateString() === selectedDate.toDateString();
+
               return (
                 <TouchableOpacity
                   key={index}
@@ -419,20 +450,34 @@ const WeekView: React.FC<WeekViewProps> = ({
                   onPress={() => onDateSelect(day)}
                 >
                   <Text style={styles.dayName}>{dayName}</Text>
-                  <Text style={[
-                    styles.dayNumber,
-                    isTodayDate && styles.dayNumberToday
-                  ]}>
-                    {dayNumber}
-                  </Text>
+                  <View
+                    style={[
+                      styles.dayNumberWrapper,
+                      isSelectedDate
+                        ? styles.dayNumberWrapperSelected
+                        : styles.dayNumberWrapperUnselected,
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.dayNumber,
+                        isSelectedDate
+                          ? styles.dayNumberSelected
+                          : styles.dayNumberUnselected,
+                      ]}
+                    >
+                      {dayNumber}
+                    </Text>
+                  </View>
                 </TouchableOpacity>
               );
             })}
           </View>
 
           {/* Timeline avec heures et événements */}
-          <ScrollView style={styles.scrollContainer} showsVerticalScrollIndicator={false}>
-            <View style={styles.timelineContainer}>
+          <View style={styles.agendaContainer}>
+            <ScrollView style={styles.scrollContainer} showsVerticalScrollIndicator={false}>
+              <View style={styles.timelineContainer}>
               {/* Colonne des heures */}
               <View style={styles.timelineColumn}>
                 {hours.map((hour) => (

--- a/src/theme/theme.adult.ts
+++ b/src/theme/theme.adult.ts
@@ -38,6 +38,11 @@ const adultTheme: Theme = {
     warning: '#FF9800', // Couleur d'avertissement
     error: '#F44336', // Couleur d'erreur
     surface: '#f8f9fa', // Couleur de surface pour les éléments UI
+
+    // Couleurs navigation agenda
+    calendarNavBackground: '#FEE8F0',
+    calendarNavIcon: '#EA3A70',
+    calendarTodayBackground: '#EA3A70',
   },
   layout: {
     headerHeightCalendar: 'clamp(200px, 30vh, 260px)', // Hauteur responsive pour le header calendrier

--- a/src/theme/theme.child.ts
+++ b/src/theme/theme.child.ts
@@ -40,6 +40,11 @@ const childTheme: Theme = {
     warning: '#FF9800', // Couleur d'avertissement
     error: '#F44336', // Couleur d'erreur
     surface: '#F5F5F5', // Couleur de surface pour les éléments UI
+
+    // Couleurs navigation agenda
+    calendarNavBackground: '#FEE8F0',
+    calendarNavIcon: '#EA3A70',
+    calendarTodayBackground: '#EA3A70',
   },
   layout: {
     headerHeightCalendar: 'clamp(200px, 30vh, 260px)', // Hauteur responsive pour le header calendrier

--- a/src/theme/theme.teen.ts
+++ b/src/theme/theme.teen.ts
@@ -40,6 +40,11 @@ const teenTheme: Theme = {
     warning: '#FF9800', // Couleur d'avertissement
     error: '#F44336', // Couleur d'erreur
     surface: '#F5F5F5', // Couleur de surface pour les éléments UI
+
+    // Couleurs navigation agenda
+    calendarNavBackground: '#FEE8F0',
+    calendarNavIcon: '#EA3A70',
+    calendarTodayBackground: '#EA3A70',
   },
   layout: {
     headerHeightCalendar: 'clamp(200px, 30vh, 260px)', // Hauteur responsive pour le header calendrier

--- a/src/theme/theme.types.ts
+++ b/src/theme/theme.types.ts
@@ -43,6 +43,11 @@ export interface ThemeColors {
   warning: string; // Couleur d'avertissement
   error: string; // Couleur d'erreur
   surface: string; // Couleur de surface pour les éléments UI
+
+  // 👇 Couleurs spécifiques pour la navigation agenda 👇
+  calendarNavBackground: string; // Fond des flèches de navigation semaine
+  calendarNavIcon: string; // Couleur des icônes de navigation semaine
+  calendarTodayBackground: string; // Fond du bouton "Aujourd'hui"
 }
 
 export interface ThemeLayout {


### PR DESCRIPTION
## Summary
- implement Monday-first week layout
- style week header navigation buttons
- highlight selected day numbers
- wrap week events grid in white rounded container
- expose new theme tokens

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684856e1ae088327b6be9d012ac2621b