### PR TITLE
Enable event completion via swipe right

### DIFF
--- a/src/components/calendar/AgendaView.tsx
+++ b/src/components/calendar/AgendaView.tsx
@@ -12,6 +12,7 @@ type AgendaViewProps = {
   onEventCreate: (dateWithTime?: Date) => void;
   currentDate: Date;
   onEventDelete: (eventId: string) => void;
+  onEventComplete: (eventId: string) => void;
 };
 
 type EventSection = {
@@ -25,7 +26,8 @@ const AgendaView: React.FC<AgendaViewProps> = ({
   onEventSelect,
   onEventCreate,
   currentDate,
-  onEventDelete
+  onEventDelete,
+  onEventComplete
 }) => {
   const theme = useTheme();
 
@@ -109,15 +111,31 @@ const AgendaView: React.FC<AgendaViewProps> = ({
     </TouchableOpacity>
   );
 
+  const renderLeftActions = (event: CalendarEvent) => (
+    <TouchableOpacity
+      style={[styles.completeAction, { backgroundColor: theme.colors.success }]}
+      onPress={() => onEventComplete(event.id)}
+    >
+      <Text style={styles.completeActionText}>Terminé</Text>
+    </TouchableOpacity>
+  );
+
   const renderEventItem = ({ item }: { item: CalendarEvent }) => (
     <Swipeable
       renderRightActions={() => renderRightActions(item)}
-      onSwipeableOpen={() => onEventDelete(item.id)}
+      renderLeftActions={() => renderLeftActions(item)}
+      onSwipeableOpen={(direction) => {
+        if (direction === 'right') {
+          onEventDelete(item.id);
+        } else if (direction === 'left') {
+          onEventComplete(item.id);
+        }
+      }}
     >
       <ModernEventCard
         event={item}
         onEdit={() => onEventSelect(item)}
-        onComplete={() => {/* TODO: Implement complete */}}
+        onComplete={() => onEventComplete(item.id)}
       />
     </Swipeable>
   );
@@ -202,7 +220,17 @@ const AgendaView: React.FC<AgendaViewProps> = ({
       alignItems: 'flex-end',
       paddingHorizontal: 20,
     },
+    completeAction: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'flex-start',
+      paddingHorizontal: 20,
+    },
     deleteActionText: {
+      color: theme.colors.background,
+      fontWeight: '600',
+    },
+    completeActionText: {
       color: theme.colors.background,
       fontWeight: '600',
     },

--- a/src/components/calendar/CalendarScreen.tsx
+++ b/src/components/calendar/CalendarScreen.tsx
@@ -150,6 +150,14 @@ const CalendarScreen: React.FC<CalendarScreenProps> = ({
     }
   };
 
+  const handleEventComplete = async (eventId: string) => {
+    try {
+      await completeEvent(eventId);
+    } catch (error) {
+      console.error('Erreur lors de la complétion de l\'événement:', error);
+    }
+  };
+
   const renderCalendarView = () => {
     switch (viewMode) {
       case 'week':
@@ -180,6 +188,7 @@ const CalendarScreen: React.FC<CalendarScreenProps> = ({
             onEventSelect={handleEventSelect}
             onEventCreate={handleEventCreate}
             onEventDelete={handleEventDelete}
+            onEventComplete={handleEventComplete}
             currentDate={currentDate}
           />
         );

--- a/src/services/calendarService.js
+++ b/src/services/calendarService.js
@@ -262,6 +262,7 @@ export const calendarService = {
       // Mise à jour
       await this.updateEvent(familyId, eventId, {
         completed: true,
+        status: 'completed',
         completedBy: currentUserId,
         completedAt: new Date()
       });
@@ -294,6 +295,7 @@ export const calendarService = {
       // Mise à jour
       await this.updateEvent(familyId, eventId, {
         completed: false,
+        status: 'pending',
         completedBy: null,
         completedAt: null
       });


### PR DESCRIPTION
## Summary
- mark calendar events as complete when swiping right in AgendaView
- wire new event completion action in CalendarScreen
- update calendarService to store completed status

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: expo config missing)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492de6b6688327baa4f48be6986e0a